### PR TITLE
Adds initial Finagle Adjuster

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ An adjuster conditionally changes spans sharing the same trace ID.
 You can make adjusters to fixup data reported by instrumentation, or to
 scrub private data.
 
-TODO: briefly describe and link to built-in adjusters
+Adjuster | Description
+--- | --- | ---
+[Finagle](./adjuster/finagle) | Fixes up spans reported by [Finagle](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
 
 ### Consumer
 A consumer is an end-recipient of potentially adjusted spans sharing the

--- a/adjuster/finagle/README.md
+++ b/adjuster/finagle/README.md
@@ -1,0 +1,21 @@
+# adjuster-finagle
+
+## FinagleAdjuster
+This fixes up spans reported by [Finagle](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
+
+Adjustment code should not be added without a tracking issue either in
+[Finagle](https://github.com/twitter/finagle/issues) or [Zipkin Finagle](https://github.com/openzipkin/zipkin-finagle/issues).
+
+## Configuration
+FinagleAdjuster can be used as a library, where attributes are set via
+`FinagleAdjuster.Builder`.
+
+It is more commonly enabled with Spring via autoconfiguration when
+"zipkin.sparkstreaming.adjuster.finagle.enabled" is set to "true"
+
+Here are the relevant setting and a short description. Properties all
+have a prefix of "zipkin.sparkstreaming.adjuster.finagle"
+
+Attribute | Property | Description | Fix
+--- | --- | --- | ---
+applyTimestampAndDuration | apply-timestamp-and-duration | Backfill span.timestamp and duration based on annotations. Defaults to true | [Use zipkin-finagle](https://github.com/openzipkin/zipkin-finagle/issues/10)

--- a/adjuster/finagle/pom.xml
+++ b/adjuster/finagle/pom.xml
@@ -14,31 +14,28 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.sparkstreaming</groupId>
-    <artifactId>zipkin-sparkstreaming-parent</artifactId>
+    <artifactId>zipkin-sparkstreaming-adjuster-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
   </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>zipkin-sparkstreaming-adjuster-parent</artifactId>
-  <name>Zipkin Spark Streaming: Adjusters</name>
-  <packaging>pom</packaging>
+  <artifactId>zipkin-sparkstreaming-adjuster-finagle</artifactId>
+  <name>Zipkin Spark Streaming Adjuster: Finagle</name>
 
   <properties>
-    <main.basedir>${project.basedir}/..</main.basedir>
+    <main.basedir>${project.basedir}/../..</main.basedir>
   </properties>
-
-  <modules>
-    <module>finagle</module>
-  </modules>
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-sparkstreaming</artifactId>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/adjuster/finagle/src/main/java/zipkin/sparkstreaming/adjuster/finagle/FinagleAdjuster.java
+++ b/adjuster/finagle/src/main/java/zipkin/sparkstreaming/adjuster/finagle/FinagleAdjuster.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.adjuster.finagle;
+
+import com.google.auto.value.AutoValue;
+import zipkin.BinaryAnnotation;
+import zipkin.Span;
+import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.sparkstreaming.Adjuster;
+
+/**
+ * Contains adjustments that pertain to Finagle tracing. Detection is based on the binary
+ * annotations named ".*finagle.version.*".
+ */
+@AutoValue
+public abstract class FinagleAdjuster extends Adjuster {
+
+  public static Builder newBuilder() {
+    return new AutoValue_FinagleAdjuster.Builder()
+        .applyTimestampAndDuration(true);
+  }
+
+  abstract boolean applyTimestampAndDuration();
+
+  @AutoValue.Builder
+  public interface Builder {
+    /**
+     * As of Finagle 6.41.0, tracing is always RPC in nature, but timestamp and duration are not
+     * added. This backfills timestamps. Default true
+     *
+     * <p>The current fix is to use zipkin-finagle to report spans.
+     * See https://github.com/openzipkin/zipkin-finagle/issues/10
+     */
+    Builder applyTimestampAndDuration(boolean applyTimestampAndDuration);
+
+    FinagleAdjuster build();
+  }
+
+  @Override protected boolean shouldAdjust(Span span) {
+    for (BinaryAnnotation b : span.binaryAnnotations) {
+      if (b.key.indexOf("finagle.version") != -1) return true;
+    }
+    return false;
+  }
+
+  @Override protected Span adjust(Span span) {
+    if (applyTimestampAndDuration()) {
+      return ApplyTimestampAndDuration.apply(span);
+    }
+    return span;
+  }
+
+  FinagleAdjuster() {
+  }
+}

--- a/adjuster/finagle/src/test/java/zipkin/sparkstreaming/adjuster/finagle/FinagleAdjusterTest.java
+++ b/adjuster/finagle/src/test/java/zipkin/sparkstreaming/adjuster/finagle/FinagleAdjusterTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.adjuster.finagle;
+
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.TestObjects;
+import zipkin.internal.ApplyTimestampAndDuration;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FinagleAdjusterTest {
+  FinagleAdjuster adjuster = FinagleAdjuster.newBuilder().build();
+
+  Endpoint localEndpoint =
+      Endpoint.builder().serviceName("my-host").ipv4(127 << 24 | 1).port(9411).build();
+  Endpoint localEndpoint0 = localEndpoint.toBuilder().port(null).build();
+  // finagle often sets to the client endpoint to the same as the local endpoint
+  Endpoint remoteEndpoint = localEndpoint.toBuilder().port(63840).build();
+
+  Span serverSpan = Span.builder()
+      .traceId(-6054243957716233329L)
+      .name("my-span")
+      .id(-3615651937927048332L)
+      .parentId(-6054243957716233329L)
+      .addAnnotation(Annotation.create(1442493420635000L, Constants.SERVER_RECV, localEndpoint))
+      .addAnnotation(Annotation.create(1442493422680000L, Constants.SERVER_SEND, localEndpoint))
+      .addBinaryAnnotation(BinaryAnnotation.create("srv/finagle.version", "6.28.0", localEndpoint0))
+      .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, localEndpoint))
+      .addBinaryAnnotation(BinaryAnnotation.address(Constants.CLIENT_ADDR, remoteEndpoint))
+      .build();
+
+  /** Default is to apply timestamp and duration */
+  @Test
+  public void adjustsFinagleSpans() throws Exception {
+    Iterable<Span> adjusted = adjuster.adjust(asList(serverSpan));
+    assertThat(adjusted).containsExactly(ApplyTimestampAndDuration.apply(serverSpan));
+  }
+
+  @Test
+  public void applyTimestampAndDuration_disabled() throws Exception {
+    adjuster = FinagleAdjuster.newBuilder().applyTimestampAndDuration(false).build();
+    Iterable<Span> adjusted = adjuster.adjust(asList(serverSpan));
+    assertThat(adjusted).containsExactly(serverSpan);
+  }
+
+  @Test
+  public void doesntAdjustNonFinagleSpans() throws Exception {
+    Iterable<Span> adjusted = adjuster.adjust(TestObjects.TRACE);
+    assertThat(adjusted).containsExactlyElementsOf(TestObjects.TRACE);
+  }
+}

--- a/autoconfigure/adjuster-finagle/pom.xml
+++ b/autoconfigure/adjuster-finagle/pom.xml
@@ -14,31 +14,26 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.sparkstreaming</groupId>
-    <artifactId>zipkin-sparkstreaming-parent</artifactId>
+    <artifactId>zipkin-sparkstreaming-autoconfigure-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
   </parent>
-
-  <artifactId>zipkin-sparkstreaming-adjuster-parent</artifactId>
-  <name>Zipkin Spark Streaming: Adjusters</name>
-  <packaging>pom</packaging>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>zipkin-sparkstreaming-autoconfigure-adjuster-finagle</artifactId>
+  <name>Zipkin Spark Streaming Auto Configure: Finagle Adjuster</name>
 
   <properties>
-    <main.basedir>${project.basedir}/..</main.basedir>
+    <main.basedir>${project.basedir}/../..</main.basedir>
   </properties>
-
-  <modules>
-    <module>finagle</module>
-  </modules>
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-sparkstreaming</artifactId>
+      <groupId>io.zipkin.sparkstreaming</groupId>
+      <artifactId>zipkin-sparkstreaming-adjuster-finagle</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/autoconfigure/adjuster-finagle/src/main/java/zipkin/sparkstreaming/autoconfigure/adjuster/finagle/ZipkinFinagleAdjusterAutoConfiguration.java
+++ b/autoconfigure/adjuster-finagle/src/main/java/zipkin/sparkstreaming/autoconfigure/adjuster/finagle/ZipkinFinagleAdjusterAutoConfiguration.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.autoconfigure.adjuster.finagle;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin.sparkstreaming.Adjuster;
+
+@Configuration
+@EnableConfigurationProperties(ZipkinFinagleAdjusterProperties.class)
+@ConditionalOnProperty(
+    value = "zipkin.sparkstreaming.adjuster.finagle.enabled",
+    havingValue = "true"
+)
+public class ZipkinFinagleAdjusterAutoConfiguration {
+
+  @Bean
+  Adjuster finagleAdjuster(ZipkinFinagleAdjusterProperties properties) {
+    return properties.toBuilder().build();
+  }
+}
+

--- a/autoconfigure/adjuster-finagle/src/main/java/zipkin/sparkstreaming/autoconfigure/adjuster/finagle/ZipkinFinagleAdjusterProperties.java
+++ b/autoconfigure/adjuster-finagle/src/main/java/zipkin/sparkstreaming/autoconfigure/adjuster/finagle/ZipkinFinagleAdjusterProperties.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.autoconfigure.adjuster.finagle;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.sparkstreaming.adjuster.finagle.FinagleAdjuster;
+
+@ConfigurationProperties("zipkin.sparkstreaming.adjuster.finagle")
+public class ZipkinFinagleAdjusterProperties {
+  private boolean applyTimestampAndDuration = true;
+
+  public boolean isApplyTimestampAndDuration() {
+    return applyTimestampAndDuration;
+  }
+
+  public void setApplyTimestampAndDuration(boolean applyTimestampAndDuration) {
+    this.applyTimestampAndDuration = applyTimestampAndDuration;
+  }
+
+  FinagleAdjuster.Builder toBuilder() {
+    return FinagleAdjuster.newBuilder()
+        .applyTimestampAndDuration(applyTimestampAndDuration);
+  }
+}

--- a/autoconfigure/adjuster-finagle/src/main/resources/META-INF/spring.factories
+++ b/autoconfigure/adjuster-finagle/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+zipkin.sparkstreaming.autoconfigure.adjuster.finagle.ZipkinFinagleAdjusterAutoConfiguration

--- a/autoconfigure/adjuster-finagle/src/test/java/zipkin/sparkstreaming/adjuster/finagle/ZipkinFinagleAdjusterAutoConfigurationTest.java
+++ b/autoconfigure/adjuster-finagle/src/test/java/zipkin/sparkstreaming/adjuster/finagle/ZipkinFinagleAdjusterAutoConfigurationTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.adjuster.finagle;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.sparkstreaming.autoconfigure.adjuster.finagle.ZipkinFinagleAdjusterAutoConfiguration;
+import zipkin.sparkstreaming.autoconfigure.adjuster.finagle.ZipkinFinagleAdjusterProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinFinagleAdjusterAutoConfigurationTest {
+
+  AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @After
+  public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test
+  public void doesntProvideAdjusterWhenDisabled() {
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinFinagleAdjusterProperties.class,
+        ZipkinFinagleAdjusterAutoConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(FinagleAdjuster.class);
+  }
+
+  @Test
+  public void providesAdjusterWhenEnabled() {
+    addEnvironment(context,
+        "zipkin.sparkstreaming.adjuster.finagle.enabled:" + true);
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinFinagleAdjusterAutoConfiguration.class);
+    context.refresh();
+
+    FinagleAdjuster adjuster = context.getBean(FinagleAdjuster.class);
+    assertThat(adjuster.applyTimestampAndDuration()).isTrue();
+  }
+
+  @Test
+  public void disableTimestampAndDuration() {
+    addEnvironment(context,
+        "zipkin.sparkstreaming.adjuster.finagle.enabled:" + true,
+        "zipkin.sparkstreaming.adjuster.finagle.apply-timestamp-and-duration:" + false);
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinFinagleAdjusterAutoConfiguration.class);
+    context.refresh();
+
+    FinagleAdjuster adjuster = context.getBean(FinagleAdjuster.class);
+    assertThat(adjuster.applyTimestampAndDuration()).isFalse();
+  }
+}

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -36,6 +36,7 @@
 
   <modules>
     <module>stream-kafka</module>
+    <module>adjuster-finagle</module>
   </modules>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,18 @@
       </dependency>
 
       <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sparkstreaming-adjuster-finagle</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sparkstreaming-autoconfigure-adjuster-finagle</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.zipkin.java</groupId>
         <artifactId>zipkin</artifactId>
         <version>${zipkin.version}</version>

--- a/sparkstreaming-job/pom.xml
+++ b/sparkstreaming-job/pom.xml
@@ -51,6 +51,16 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sparkstreaming-autoconfigure-stream-kafka</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sparkstreaming-autoconfigure-adjuster-finagle</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>

--- a/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJob.java
+++ b/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJob.java
@@ -13,7 +13,6 @@
  */
 package zipkin.sparkstreaming.job;
 
-import java.io.UnsupportedEncodingException;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -22,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import zipkin.sparkstreaming.Consumer;
 import zipkin.sparkstreaming.SparkStreamingJob;
+import zipkin.sparkstreaming.autoconfigure.adjuster.finagle.ZipkinFinagleAdjusterAutoConfiguration;
 import zipkin.sparkstreaming.autoconfigure.stream.kafka.ZipkinKafkaStreamFactoryAutoConfiguration;
 
 @SpringBootApplication
@@ -29,18 +29,18 @@ import zipkin.sparkstreaming.autoconfigure.stream.kafka.ZipkinKafkaStreamFactory
     ZipkinSparkStreamingConfiguration.class,
     ZipkinSparkStreamingJob.TemporaryConfiguration.class,
     // These need to be explicity included as the shade plugin squashes spring.properties
-    ZipkinKafkaStreamFactoryAutoConfiguration.class
+    ZipkinKafkaStreamFactoryAutoConfiguration.class,
+    ZipkinFinagleAdjusterAutoConfiguration.class
 })
 public class ZipkinSparkStreamingJob {
 
-  public static void main(String[] args) throws UnsupportedEncodingException {
+  public static void main(String[] args) {
     new SpringApplicationBuilder(ZipkinSparkStreamingJob.class)
         .run(args)
         .getBean(SparkStreamingJob.class).awaitTermination();
   }
 
-  // We need to use eventually us auto-configuration for StreamFactory and Consumer.
-  // This is an example, that seeds a single span (then loops forever since no more spans arrive).
+  // What's left is to make a storage consumer
   @Configuration
   static class TemporaryConfiguration {
     @Bean @ConditionalOnMissingBean Consumer consumer() {


### PR DESCRIPTION
This fixes up spans reported by [Finagle](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).

Adjustment code should not be added without a tracking issue either in
[Finagle](https://github.com/twitter/finagle/issues) or [Zipkin Finagle](https://github.com/openzipkin/zipkin-finagle/issues).

FinagleAdjuster can be used as a library, where attributes are set via
`FinagleAdjuster.Builder`.

It is more commonly enabled with Spring via autoconfiguration when
"zipkin.sparkstreaming.adjuster.finagle.enabled" is set to "true"

Here are the relevant setting and a short description. Properties all
have a prefix of "zipkin.sparkstreaming.adjuster.finagle"

Attribute | Property | Description | Fix
--- | --- | --- | ---
applyTimestampAndDuration | apply-timestamp-and-duration | Backfill span.timestamp and duration based on annotations. Defaults to true | [Use zipkin-finagle](https://github.com/openzipkin/zipkin-finagle/issues/10)