### PR TITLE
Adding KafkaStreamFactory for ingesting spans from kafka transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For example, a message stream could be a Kafka topic named "zipkin"
 
 Stream | Description
 --- | --- | ---
-[Kafka](./stream/kafka) | Ingests spans from a Kafka topic.
+[Kafka](./stream/kafka) | Ingests spans from a Kafka topic
 
 ### Adjuster
 An adjuster conditionally changes spans sharing the same trace ID.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ A stream is a source of json or thrift encoded span messages.
 
 For example, a message stream could be a Kafka topic named "zipkin"
 
-TODO: briefly describe and link to built-in message stream factories
+Stream | Description
+--- | --- | ---
+[Kafka](./stream/kafka) | Ingests spans from a Kafka topic.
 
 ### Adjuster
 An adjuster conditionally changes spans sharing the same trace ID.

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -34,6 +34,7 @@
 
   <modules>
     <module>sparkstreaming</module>
+    <module>stream-kafka</module>
   </modules>
 
   <dependencyManagement>

--- a/autoconfigure/stream-kafka/pom.xml
+++ b/autoconfigure/stream-kafka/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.zipkin.sparkstreaming</groupId>
+        <artifactId>zipkin-sparkstreaming-autoconfigure-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>zipkin-sparkstreaming-autoconfigure-stream-kafka</artifactId>
+    <name>Zipkin Spark Streaming Auto Configure: Kafka Stream</name>
+
+    <properties>
+        <main.basedir>${project.basedir}/../..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.sparkstreaming</groupId>
+            <artifactId>zipkin-sparkstreaming-stream-kafka</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryAutoConfiguration.java
+++ b/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryAutoConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.autoconfigure.stream.kafka;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin.sparkstreaming.StreamFactory;
+
+@Configuration
+@EnableConfigurationProperties(ZipkinKafkaStreamFactoryProperties.class)
+public class ZipkinKafkaStreamFactoryAutoConfiguration {
+
+  @Bean
+  StreamFactory kafkaStream(ZipkinKafkaStreamFactoryProperties properties) {
+    return properties.toBuilder().build();
+  }
+}

--- a/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryProperties.java
+++ b/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryProperties.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.autoconfigure.stream.kafka;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.sparkstreaming.stream.kafka.KafkaStreamFactory;
+
+@ConfigurationProperties("zipkin.sparkstreaming.stream.kafka")
+public class ZipkinKafkaStreamFactoryProperties {
+  private String topic;
+  private String zookeeper;
+  private String zkConnectionPath;
+  private Integer zkSessionTimeout;
+
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = "".equals(topic) ? null : topic;
+  }
+
+  public String getZookeeper() {
+    return zookeeper;
+  }
+
+  public void setZookeeper(String zookeeper) {
+    this.zookeeper = "".equals(zookeeper) ? null : zookeeper;
+  }
+
+  public String getZkConnectionPath() {
+    return zkConnectionPath;
+  }
+
+  public void setZkConnectionPath(String zkConnectionPath) {
+    this.zkConnectionPath = "".equals(zkConnectionPath) ? null : zkConnectionPath;
+  }
+
+  public Integer getZkSessionTimeout() {
+    return zkSessionTimeout;
+  }
+
+  public void setZkSessionTimeout(Integer zkSessionTimeout) {
+    this.zkSessionTimeout = zkSessionTimeout;
+  }
+
+  KafkaStreamFactory.Builder toBuilder() {
+    KafkaStreamFactory.Builder result = KafkaStreamFactory.newBuilder();
+    if (topic != null) result = result.topic(topic);
+    if (zookeeper != null) result = result.zookeeper(zookeeper);
+    if (zkConnectionPath != null) result = result.zkConnectionPath(zkConnectionPath);
+    if (zkSessionTimeout != null) result = result.zkSessionTimeout(zkSessionTimeout);
+
+    return result;
+  }
+}

--- a/autoconfigure/stream-kafka/src/main/resource/META-INF/spring.factories
+++ b/autoconfigure/stream-kafka/src/main/resource/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+zipkin.autoconfigure.sparkstreaming.ZipkinSparkStreamingAutoConfiguration

--- a/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZipkinKafkaStreamFactoryAutoConfigurationTest.java
+++ b/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZipkinKafkaStreamFactoryAutoConfigurationTest.java
@@ -36,8 +36,8 @@ public class ZipkinKafkaStreamFactoryAutoConfigurationTest {
     addEnvironment(context,
         "zipkin.sparkstreaming.stream.kafka.topic:topic",
         "zipkin.sparkstreaming.stream.kafka.zookeeper:zookeeper",
-        "zipkin.sparkstreaming.stream.kafka.zkConnectionPath:zkConnectionPath",
-        "zipkin.sparkstreaming.stream.kafka.zkSessionTimeout:" + 1);
+        "zipkin.sparkstreaming.stream.kafka.zk-connection-path:zkConnectionPath",
+        "zipkin.sparkstreaming.stream.kafka.zk-session-timeout:" + 1);
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinKafkaStreamFactoryAutoConfiguration.class);
     context.refresh();

--- a/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZipkinKafkaStreamFactoryAutoConfigurationTest.java
+++ b/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZipkinKafkaStreamFactoryAutoConfigurationTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.stream.kafka;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.sparkstreaming.autoconfigure.stream.kafka.ZipkinKafkaStreamFactoryAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinKafkaStreamFactoryAutoConfigurationTest {
+
+  AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+  @After
+  public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test
+  public void setPropertiesTest() {
+    addEnvironment(context,
+        "zipkin.sparkstreaming.stream.kafka.topic:topic",
+        "zipkin.sparkstreaming.stream.kafka.zookeeper:zookeeper",
+        "zipkin.sparkstreaming.stream.kafka.zkConnectionPath:zkConnectionPath",
+        "zipkin.sparkstreaming.stream.kafka.zkSessionTimeout:" + 1);
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinKafkaStreamFactoryAutoConfiguration.class);
+    context.refresh();
+
+    KafkaStreamFactory streamFactory = context.getBean(KafkaStreamFactory.class);
+    assertThat(streamFactory.topic()).isEqualTo("topic");
+    assertThat(streamFactory.zookeeper()).isEqualTo("zookeeper");
+    assertThat(streamFactory.zkConnectionPath()).isEqualTo("zkConnectionPath");
+    assertThat(streamFactory.zkSessionTimeout()).isEqualTo(1);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,18 @@
       </dependency>
 
       <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sparkstreaming-stream-kafka</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sparkstreaming-autoconfigure-stream-kafka</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.zipkin.java</groupId>
         <artifactId>zipkin</artifactId>
         <version>${zipkin.version}</version>

--- a/sparkstreaming-job/pom.xml
+++ b/sparkstreaming-job/pom.xml
@@ -56,6 +56,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sparkstreaming-autoconfigure-stream-kafka</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>

--- a/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJob.java
+++ b/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJob.java
@@ -33,13 +33,15 @@ import zipkin.autoconfigure.sparkstreaming.ZipkinSparkStreamingAutoConfiguration
 import zipkin.sparkstreaming.Consumer;
 import zipkin.sparkstreaming.SparkStreamingJob;
 import zipkin.sparkstreaming.StreamFactory;
+import zipkin.sparkstreaming.autoconfigure.stream.kafka.ZipkinKafkaStreamFactoryAutoConfiguration;
 
 import static java.util.Arrays.asList;
 
 @SpringBootApplication
 @Import({
     ZipkinSparkStreamingAutoConfiguration.class,
-    ZipkinSparkStreamingJob.DummyConfiguration.class
+    ZipkinSparkStreamingJob.DummyConfiguration.class,
+    ZipkinKafkaStreamFactoryAutoConfiguration.class
 })
 public class ZipkinSparkStreamingJob {
 
@@ -54,17 +56,6 @@ public class ZipkinSparkStreamingJob {
   // This is an example, that seeds a single span (then loops forever since no more spans arrive).
   @Configuration
   static class DummyConfiguration {
-
-    // This creates only one trace, so isn't that interesting.
-    @Bean StreamFactory streamFactory() {
-      return jsc -> {
-        Queue<JavaRDD<byte[]>> rddQueue = new LinkedList<>();
-        byte[] oneSpan = Codec.JSON.writeSpans(asList(span(1L)));
-        rddQueue.add(jsc.sparkContext().parallelize(Collections.singletonList(oneSpan)));
-        return jsc.queueStream(rddQueue);
-      };
-    }
-
     @Bean Consumer consumer() {
       return trace -> System.err.println(trace);
     }

--- a/sparkstreaming-job/src/test/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJobIntegrationTest.java
+++ b/sparkstreaming-job/src/test/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJobIntegrationTest.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import zipkin.sparkstreaming.SparkStreamingJob;
+import zipkin.sparkstreaming.StreamFactory;
+import zipkin.sparkstreaming.stream.kafka.KafkaStreamFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,11 +30,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(
     classes = ZipkinSparkStreamingJob.class,
     properties = {
+        // update before running test
+        "zipkin.sparkstreaming.stream.kafka.zookeeper:1.1.1.1:2222",
+        "zipkin.sparkstreaming.stream.kafka.zkConnectionPath:abc",
     }
 )
 public class ZipkinSparkStreamingJobIntegrationTest {
 
   @Autowired SparkStreamingJob job;
+
+  @Autowired StreamFactory factory;
 
   @After public void close() throws IOException {
     if (job != null) job.close();
@@ -41,4 +48,9 @@ public class ZipkinSparkStreamingJobIntegrationTest {
   @Test public void wiresJob() {
     assertThat(job).isNotNull();
   }
+
+  @Test public void wireStreamFactory() {
+    assertThat(factory).isInstanceOf(KafkaStreamFactory.class);
+  }
+
 }

--- a/sparkstreaming-job/src/test/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJobIntegrationTest.java
+++ b/sparkstreaming-job/src/test/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingJobIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     properties = {
         // update before running test
         "zipkin.sparkstreaming.stream.kafka.zookeeper:1.1.1.1:2222",
-        "zipkin.sparkstreaming.stream.kafka.zkConnectionPath:abc",
+        "zipkin.sparkstreaming.stream.kafka.zk-connection-path:abc",
     }
 )
 public class ZipkinSparkStreamingJobIntegrationTest {

--- a/sparkstreaming/src/main/java/zipkin/sparkstreaming/SparkStreamingJob.java
+++ b/sparkstreaming/src/main/java/zipkin/sparkstreaming/SparkStreamingJob.java
@@ -157,7 +157,7 @@ public abstract class SparkStreamingJob implements Closeable {
           for (Adjuster adjuster : adjusters) {
             trace = adjuster.adjust(trace);
           }
-          consumer.accept(p.next());
+          consumer.accept(trace);
         }
       });
     });

--- a/stream/kafka/README.md
+++ b/stream/kafka/README.md
@@ -5,7 +5,7 @@
 This stream ingests Spans form a Kafka topic advertised by Zookeeper, using Spark Kafka libraries.
 
 Kafka messages should contain a list of spans in json or TBinaryProtocol big-endian encoding.
-Details on message encode is available [here](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector/kafka/README.md#encoding-spans-into-kafka-messages)
+Details on message encoding is available [here](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector/kafka/README.md#encoding-spans-into-kafka-messages)
 
 ## Configuration
 KafkaStream can be used as a library, where attributes are set via
@@ -18,5 +18,5 @@ Attribute | Property | Description
 --- | --- | ---
 topic | topic | Kafka topic zipkin spans will be consumed from. Defaults to "zipkin"
 zookeeper | zookeeper | Comma separated host:port pairs, each corresponding to a Zookeeper server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002". No default
-zkConnectionPath | zkConnectionPath | Connection path for Zookeeper. Used as suffix for zk connection string. No default
-zkSessionTimeout | zkSessionTimeout | Zookeeper session timeout. Defaults to “10000”
+zkConnectionPath | zk-connection-path | Connection path for Zookeeper. Used as suffix for zk connection string. No default
+zkSessionTimeout | zk-session-timeout | Zookeeper session timeout. Defaults to “10000”

--- a/stream/kafka/README.md
+++ b/stream/kafka/README.md
@@ -1,0 +1,22 @@
+# stream-kafka
+
+## KafkaStream
+
+This stream ingests Spans form a Kafka topic advertised by Zookeeper, using Spark Kafka libraries.
+
+Kafka messages should contain a list of spans in json or TBinaryProtocol big-endian encoding.
+Details on message encode is available [here](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector/kafka/README.md#encoding-spans-into-kafka-messages)
+
+## Configuration
+KafkaStream can be used as a library, where attributes are set via
+`KafkaStreamFactory.Builder`. It is more commonly enabled with Spring via autoconfiguration.
+
+Here are the relevant setting and a short description. All properties
+have a prefix of "zipkin.sparkstreaming.stream.kafka"
+
+Attribute | Property | Description
+--- | --- | ---
+topic | topic | Kafka topic zipkin spans will be consumed from. Defaults to "zipkin"
+zookeeper | zookeeper | Comma separated host:port pairs, each corresponding to a Zookeeper server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002". No default
+zkConnectionPath | zkConnectionPath | Connection path for Zookeeper. Used as suffix for zk connection string. No default
+zkSessionTimeout | zkSessionTimeout | Zookeeper session timeout. Defaults to “10000”

--- a/stream/kafka/pom.xml
+++ b/stream/kafka/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.zipkin.sparkstreaming</groupId>
+        <artifactId>zipkin-sparkstreaming-stream-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>zipkin-sparkstreaming-stream-kafka</artifactId>
+    <name>Zipkin Spark Streaming Stream: Kafka</name>
+
+    <properties>
+        <main.basedir>${project.basedir}/../..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming-kafka_2.10</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/stream/kafka/src/main/java/zipkin/sparkstreaming/stream/kafka/KafkaStreamFactory.java
+++ b/stream/kafka/src/main/java/zipkin/sparkstreaming/stream/kafka/KafkaStreamFactory.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.stream.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auto.value.AutoValue;
+import kafka.serializer.DefaultDecoder;
+import org.apache.commons.lang.StringUtils;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.apache.spark.streaming.kafka.KafkaUtils;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.sparkstreaming.StreamFactory;
+
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Ingests Spans form a Kafka topic advertised by Zookeeper
+ */
+@AutoValue
+public abstract class KafkaStreamFactory implements StreamFactory {
+
+  abstract String topic();
+  abstract String zookeeper();
+  abstract String zkConnectionPath();
+  abstract Integer zkSessionTimeout();
+
+  @AutoValue.Builder
+  public interface Builder {
+
+    /**
+     * Kafka topic zipkin spans will be consumed from. Defaults to "zipkin"
+     */
+    Builder topic(String topic);
+
+    /**
+     * Comma separated host:port pairs, each corresponding to a Zookeeper server.
+     * e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+     * No default
+     */
+    Builder zookeeper(String zookeeper);
+
+    /**
+     * Connection path for Zookeeper. Used as suffix for zk connection string. No default
+     */
+    Builder zkConnectionPath(String zkConnectionPath);
+
+    /**
+     * Zookeeper session timeout. Defaults to “10000”
+     */
+    Builder zkSessionTimeout(Integer zkSessionTimeout);
+
+    KafkaStreamFactory build();
+  }
+
+  public static Builder newBuilder() {
+    return new AutoValue_KafkaStreamFactory.Builder()
+        .topic("zipkin")
+        .zkSessionTimeout(10000);
+  }
+
+  @Override
+  public JavaDStream<byte[]> create(JavaStreamingContext jsc) {
+
+    return KafkaUtils.createDirectStream(
+        jsc,
+        byte[].class,
+        byte[].class,
+        DefaultDecoder.class,
+        DefaultDecoder.class,
+        getKafkaParams(),
+        Collections.singleton(topic()))
+        .map(m -> m._2); // get value
+  }
+
+  private Map<String, String> getKafkaParams() {
+    Map<String, String> kafkaParams = new HashMap<>();
+    kafkaParams.put("metadata.broker.list", getBrokers());
+    return Collections.unmodifiableMap(kafkaParams);
+  }
+
+  private String getBrokers() {
+
+    try {
+      ZooKeeper zkClient =
+          new ZooKeeper(zookeeper() + "/" + zkConnectionPath(), zkSessionTimeout(),
+              new NoOpWatcher());
+      List<String> ids = zkClient.getChildren("/brokers/ids", false);
+      ObjectMapper objectMapper = new ObjectMapper();
+
+      List<String> brokerConnections = new ArrayList<>();
+      for (String id : ids) {
+        brokerConnections.add(getBrokerInfo(zkClient, objectMapper, id));
+      }
+
+      return StringUtils.join(brokerConnections, ",");
+
+    } catch (Exception e) {
+      throw new InvalidParameterException("Error loading brokers from zookeeper");
+    }
+
+  }
+
+  /**
+   * Builds string to create KafkaParams for Spark job
+   * @param zkClient ZooKeeper client with predefined configurations
+   * @param om ObjectMapper used to read zkClient's children (brokers)
+   * @param id broker id
+   * @return "host:port" string
+   */
+  private String getBrokerInfo(ZooKeeper zkClient, ObjectMapper om, String id) {
+    try {
+      Map map = om.readValue(
+          zkClient.getData("/brokers/ids/" + id, false, null), Map.class);
+      String host = String.valueOf(map.get("host"));
+      String port = String.valueOf(map.get("port"));
+      return host + ":" + port;
+    } catch (Exception e) {
+      throw new InvalidParameterException("Error reading zkClient's broker id's");
+    }
+  }
+
+  class NoOpWatcher implements Watcher {
+
+    private Logger logger = LoggerFactory.getLogger(NoOpWatcher.class);
+
+    @Override
+    public void process(WatchedEvent event) {
+      logger.debug(event.toString());
+    }
+  }
+
+  KafkaStreamFactory() {
+  }
+}

--- a/stream/kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/KafkaStreamFactoryTest.java
+++ b/stream/kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/KafkaStreamFactoryTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sparkstreaming.stream.kafka;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KafkaStreamFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void buildKafkaStreamFactory() throws Exception {
+    KafkaStreamFactory streamFactory = KafkaStreamFactory.newBuilder()
+        .zookeeper("127.0.0.1:3000")
+        .zkConnectionPath("traces")
+        .build();
+    assertThat(streamFactory).isNotNull();
+  }
+
+  @Test
+  public void buildFailOnMissingProperties() throws Exception {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Missing required properties: zookeeper zkConnectionPath");
+    KafkaStreamFactory streamFactory = KafkaStreamFactory.newBuilder().build();
+  }
+}

--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -32,6 +32,7 @@
   </properties>
 
   <modules>
+    <module>kafka</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
# stream-kafka

## KafkaStream

This stream ingests Spans form a Kafka topic advertised by Zookeeper, using Spark Kafka libraries.

Kafka messages should contain a list of spans in json or TBinaryProtocol big-endian encoding.
Details on message encoding is available [here](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector/kafka/README.md#encoding-spans-into-kafka-messages)

## Configuration
KafkaStream can be used as a library, where attributes are set via
`KafkaStreamFactory.Builder`. It is more commonly enabled with Spring via autoconfiguration.

Here are the relevant setting and a short description. All properties
have a prefix of "zipkin.sparkstreaming.stream.kafka"

Attribute | Property | Description
--- | --- | ---
topic | topic | Kafka topic zipkin spans will be consumed from. Defaults to "zipkin"
zookeeper | zookeeper | Comma separated host:port pairs, each corresponding to a Zookeeper server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002". No default
zkConnectionPath | zk-connection-path | Connection path for Zookeeper. Used as suffix for zk connection string. No default
zkSessionTimeout | zk-session-timeout | Zookeeper session timeout. Defaults to “10000”