### PR TITLE
Moves to the more idiomatic "zookeeper.connect" property

### DIFF
--- a/autoconfigure/stream-kafka/README.md
+++ b/autoconfigure/stream-kafka/README.md
@@ -12,7 +12,7 @@ configuration options via properties.
 
 In order to connect, you minimally need to set
 `zipkin.sparkstreaming.stream.kafka.bootstrap-servers` or
-`zipkin.sparkstreaming.stream.kafka.zookeeper.connect-servers`.
+`zipkin.sparkstreaming.stream.kafka.zookeeper.connect`.
 
 Ex.
 ```bash
@@ -34,8 +34,7 @@ Property | Default | Description
 topic | zipkin | Kafka topic encoded lists of spans are be consumed from.
 group-id | zipkin | Consumer group this process is consuming on behalf of.
 bootstrap-servers | none | Initial set of kafka servers to connect to; others may be discovered. Values are in comma-separated host:port syntax. Ex "host1:9092,host2:9092".
-zookeeper.connect-servers | none | Looks up bootstrap-servers from Zookeeper. Values are in comma-separated host:port syntax. Ex "host1:2181,host2:2181".
-zookeeper.connect-suffix | "" | Optional chroot path used as a suffix for connect string.
+zookeeper.connect | none | Looks up bootstrap-servers from Zookeeper. Values is a connect string (comma-separated host:port with optional suffix) Ex "host1:2181,host2:2181".
 zookeeper.session-timeout | 10000 | Session timeout for looking up bootstrap-servers.
 
 ## More Examples
@@ -44,6 +43,6 @@ Ex. to lookup bootstrap servers using Zookeeper
 
 ```bash
 java -jar zipkin-sparkstreaming-job.jar \
-  --zipkin.sparkstreaming.stream.kafka.zookeeper.connect-servers=127.0.0.1:2181
+  --zipkin.sparkstreaming.stream.kafka.zookeeper.connect=127.0.0.1:2181
   ...
 ```

--- a/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryAutoConfiguration.java
+++ b/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryAutoConfiguration.java
@@ -34,7 +34,7 @@ public class ZipkinKafkaStreamFactoryAutoConfiguration {
 
   static final class KafkaServersSetCondition extends SpringBootCondition {
     static final String BOOTSTRAP = "zipkin.sparkstreaming.stream.kafka.bootstrap-servers";
-    static final String CONNECT = "zipkin.sparkstreaming.stream.kafka.zookeeper.connect-servers";
+    static final String CONNECT = "zipkin.sparkstreaming.stream.kafka.zookeeper.connect";
 
     @Override
     public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata a) {

--- a/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryProperties.java
+++ b/autoconfigure/stream-kafka/src/main/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryProperties.java
@@ -60,26 +60,15 @@ public class ZipkinKafkaStreamFactoryProperties {
   }
 
   public static class Zookeeper {
-    private List<String> connectServers;
-    private String connectSuffix;
+    private String connect;
     private Integer sessionTimeout;
 
-    public List<String> getConnectServers() {
-      return connectServers;
+    public String getConnect() {
+      return connect;
     }
 
-    public void setConnectServers(List<String> connectServers) {
-      if (connectServers != null && !connectServers.isEmpty()) {
-        this.connectServers = connectServers;
-      }
-    }
-
-    public String getConnectSuffix() {
-      return connectSuffix;
-    }
-
-    public void setConnectSuffix(String connectSuffix) {
-      this.connectSuffix = emptyToNull(connectSuffix);
+    public void setConnect(String connect) {
+      this.connect = emptyToNull(connect);
     }
 
     public Integer getSessionTimeout() {
@@ -96,11 +85,11 @@ public class ZipkinKafkaStreamFactoryProperties {
     if (topic != null) result.topic(topic);
     if (groupId != null) result.groupId(groupId);
     if (bootstrapServers != null) result.bootstrapServers(bootstrapServers);
-    if (zookeeper.getConnectServers() == null) return result;
+
+    if (zookeeper.getConnect() == null) return result; // Zookeeper bootstrap is optional
 
     ZookeeperBootstrapServers.Builder supplier = ZookeeperBootstrapServers.newBuilder();
-    supplier.connectServers(zookeeper.getConnectServers());
-    if (zookeeper.connectSuffix != null) supplier.connectSuffix(zookeeper.connectSuffix);
+    supplier.connect(zookeeper.getConnect());
     if (zookeeper.sessionTimeout != null) supplier.sessionTimeout(zookeeper.sessionTimeout);
     result.bootstrapServers(supplier.build());
     return result;

--- a/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryPropertiesTest.java
+++ b/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/autoconfigure/stream/kafka/ZipkinKafkaStreamFactoryPropertiesTest.java
@@ -47,9 +47,7 @@ public class ZipkinKafkaStreamFactoryPropertiesTest {
         parameters("topic", "zapkin", p -> p.getTopic()),
         parameters("group-id", "zapkin", p -> p.getGroupId()),
         parameters("bootstrap-servers", "127.0.0.1:9092", p -> p.getBootstrapServers().get(0)),
-        parameters("zookeeper.connect-servers", "127.0.0.1:3001",
-            p -> p.getZookeeper().getConnectServers().get(0)),
-        parameters("zookeeper.connect-suffix", "/prod", p -> p.getZookeeper().getConnectSuffix()),
+        parameters("zookeeper.connect", "127.0.0.1:3001", p -> p.getZookeeper().getConnect()),
         parameters("zookeeper.session-timeout", 9999, p -> p.getZookeeper().getSessionTimeout()),
     });
   }

--- a/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZipkinKafkaStreamFactoryAutoConfigurationTest.java
+++ b/autoconfigure/stream-kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZipkinKafkaStreamFactoryAutoConfigurationTest.java
@@ -72,7 +72,7 @@ public class ZipkinKafkaStreamFactoryAutoConfigurationTest {
   @Test
   public void providesCollectorComponent_whenKafkaZookeeperSet() {
     addEnvironment(context,
-        "zipkin.sparkstreaming.stream.kafka.zookeeper.connect-servers:" + KAFKA_ZOOKEEPER
+        "zipkin.sparkstreaming.stream.kafka.zookeeper.connect:" + KAFKA_ZOOKEEPER
     );
     context.register(
         PropertyPlaceholderAutoConfiguration.class,
@@ -82,7 +82,7 @@ public class ZipkinKafkaStreamFactoryAutoConfigurationTest {
 
     ZipkinKafkaStreamFactoryProperties props =
         context.getBean(ZipkinKafkaStreamFactoryProperties.class);
-    assertThat(props.getZookeeper().getConnectServers())
-        .containsExactly(KAFKA_ZOOKEEPER);
+    assertThat(props.getZookeeper().getConnect())
+        .isEqualTo(KAFKA_ZOOKEEPER);
   }
 }

--- a/stream/kafka/src/main/java/zipkin/sparkstreaming/stream/kafka/ZookeeperBootstrapServers.java
+++ b/stream/kafka/src/main/java/zipkin/sparkstreaming/stream/kafka/ZookeeperBootstrapServers.java
@@ -18,7 +18,6 @@ import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
@@ -31,7 +30,6 @@ public abstract class ZookeeperBootstrapServers implements BootstrapServers {
 
   public static Builder newBuilder() {
     return new AutoValue_ZookeeperBootstrapServers.Builder()
-        .connectSuffix("")
         .sessionTimeout(10000);
   }
 
@@ -39,15 +37,12 @@ public abstract class ZookeeperBootstrapServers implements BootstrapServers {
   public interface Builder {
 
     /**
-     * host:port pairs corresponding to a Zookeeper server. This forms the first part of the connect
-     * string. No default
+     * Zookeeper host string. host:port pairs corresponding to a Zookeeper server with an optional
+     * chroot suffix. No default
+     *
+     * @see ZooKeeper#ZooKeeper(String, int, Watcher)
      */
-    Builder connectServers(List<String> connectServers);
-
-    /**
-     * Optional chroot path used as a suffix for connect string. Defaults to empty.
-     */
-    Builder connectSuffix(String connectSuffix);
+    Builder connect(String connect);
 
     /**
      * Zookeeper session timeout in milliseconds. Defaults to 10000
@@ -57,17 +52,14 @@ public abstract class ZookeeperBootstrapServers implements BootstrapServers {
     ZookeeperBootstrapServers build();
   }
 
-  abstract List<String> connectServers();
-
-  abstract String connectSuffix();
+  abstract String connect();
 
   abstract int sessionTimeout();
 
   @Override public List<String> get() {
-    String connectString = StringUtils.join(connectServers(), ",") + connectSuffix();
     ZooKeeper zkClient = null;
     try {
-      zkClient = new ZooKeeper(connectString, sessionTimeout(), new NoOpWatcher());
+      zkClient = new ZooKeeper(connect(), sessionTimeout(), new NoOpWatcher());
       List<String> ids = zkClient.getChildren("/brokers/ids", false);
       ObjectMapper objectMapper = new ObjectMapper();
 

--- a/stream/kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZookeeperBootstrapServersTest.java
+++ b/stream/kafka/src/test/java/zipkin/sparkstreaming/stream/kafka/ZookeeperBootstrapServersTest.java
@@ -17,7 +17,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // TODO: actually test the code
@@ -29,7 +28,7 @@ public class ZookeeperBootstrapServersTest {
   @Test
   public void buildZookeeperBootstrapServers() throws Exception {
     ZookeeperBootstrapServers servers = ZookeeperBootstrapServers.newBuilder()
-        .connectServers(asList("127.0.0.1:2181"))
+        .connect("127.0.0.1:2181")
         .build();
     assertThat(servers).isNotNull();
   }
@@ -37,7 +36,7 @@ public class ZookeeperBootstrapServersTest {
   @Test
   public void buildFailOnMissingProperties() throws Exception {
     thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Missing required properties: connectServers");
+    thrown.expectMessage("Missing required properties: connect");
     ZookeeperBootstrapServers servers = ZookeeperBootstrapServers.newBuilder().build();
   }
 }


### PR DESCRIPTION
The Kafka property for Zookeeper connect string is "zookeeper.connect".
This is also what we use in other code. I've actually not seen any code
that destructures the Zookeeper connect string.

This change reduces logic and is congruent with normal Kafka
configuration.

Fixes #13