### PR TITLE
Fixes inability to override spark conf; prefers spark-submit names

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ java -jar zipkin-sparkstreaming-job.jar \
   --zipkin.storage.type=elasticsearch \
   --zipkin.storage.elasticsearch.hosts=http://127.0.0.1:9200 \
   --zipkin.sparkstreaming.stream.kafka.bootstrap-servers=127.0.0.1:9092 \
-  --zipkin.sparkstreaming.sparkMaster=spark://127.0.0.1:7077
+  --zipkin.sparkstreaming.master=spark://127.0.0.1:7077
 ```
 
 ## Key Components

--- a/sparkstreaming-job/README.md
+++ b/sparkstreaming-job/README.md
@@ -1,0 +1,40 @@
+# sparkstreaming-job
+
+This is a Spring Boot Application that launches the spark streaming job.
+It primarily uses properties for configuration.
+
+## Usage
+
+To start the job, you need to minimally set properties for a stream
+(like kafka) and a consumer (like storage). Built-in options are located
+in the [autoconfigure](../autoconfigure) module.
+
+Ex. To receive messages from Kafka and store them into Elasticsearch:
+```bash
+java -jar zipkin-sparkstreaming-job.jar \
+  --zipkin.storage.type=elasticsearch \
+  --zipkin.storage.elasticsearch.hosts=http://127.0.0.1:9200 \
+  --zipkin.sparkstreaming.stream.kafka.bootstrap-servers=127.0.0.1:9092
+```
+
+### Configuration
+
+Configuration properties can be set via commandline parameters, system
+properties or any other alternative [supported by Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html).
+
+Here are the relevant setting and a short description. Properties all
+have a prefix of "zipkin.sparkstreaming"
+
+Property | Default | Description
+--- | --- | ---
+master | `local[*]` | The spark master used for this job. `local[*]` means run on-demand w/o connecting to a cluster.
+jars | the exec jar | Indicates which jars to distribute to the cluster.
+conf | "spark.ui.enabled=false", "spark.akka.logLifecycleEvents=true" | Overrides the properties used to create a SparkConf
+batch-duration | 10000 | The time interval in millis at which streaming data will be divided into batches
+
+Ex. to manually control spark conf, add properties prefixed with `zipkin.sparkstreaming.conf`:
+```bash
+java -jar zipkin-sparkstreaming-job.jar \
+  --zipkin.sparkstreaming.conf.spark.eventLog.enabled=false \
+  ...
+```

--- a/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingConfiguration.java
+++ b/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingConfiguration.java
@@ -46,11 +46,11 @@ public class ZipkinSparkStreamingConfiguration {
       Consumer consumer
   ) {
     SparkStreamingJob.Builder builder = sparkStreaming.toBuilder();
-    if (sparkStreaming.getSparkMaster() != null && sparkStreaming.getSparkJars() == null) {
+    if (sparkStreaming.getMaster() != null && sparkStreaming.getJars() == null) {
       List<String> pathToJars = pathToJars(ZipkinSparkStreamingJob.class, adjusters);
       if (pathToJars != null) {
         log.info("Will distribute the following jars to the cluster: " + pathToJars);
-        builder.sparkJars(pathToJars);
+        builder.jars(pathToJars);
       }
     }
     return builder.streamFactory(streamFactory)

--- a/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingProperties.java
+++ b/sparkstreaming-job/src/main/java/zipkin/sparkstreaming/job/ZipkinSparkStreamingProperties.java
@@ -13,6 +13,7 @@
  */
 package zipkin.sparkstreaming.job;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -20,34 +21,34 @@ import zipkin.sparkstreaming.SparkStreamingJob;
 
 @ConfigurationProperties("zipkin.sparkstreaming")
 public class ZipkinSparkStreamingProperties {
-  String sparkMaster;
-  List<String> sparkJars;
-  Map<String, String> sparkProperties;
+  String master;
+  List<String> jars;
+  Map<String, String> conf = new LinkedHashMap<>();
   Long batchDuration;
 
-  public String getSparkMaster() {
-    return sparkMaster;
+  public String getMaster() {
+    return master;
   }
 
-  public void setSparkMaster(String sparkMaster) {
-    this.sparkMaster = "".equals(sparkMaster) ? null : sparkMaster;
+  public void setMaster(String master) {
+    this.master = "".equals(master) ? null : master;
   }
 
-  public List<String> getSparkJars() {
-    return sparkJars;
+  public List<String> getJars() {
+    return jars;
   }
 
-  public void setSparkJars(List<String> sparkJars) {
-    if (sparkJars != null && !sparkJars.isEmpty()) this.sparkJars = sparkJars;
+  public void setJars(List<String> jars) {
+    if (jars != null && !jars.isEmpty()) this.jars = jars;
   }
 
-  public Map<String, String> getSparkProperties() {
-    return sparkProperties;
+  public Map<String, String> getConf() {
+    return conf;
   }
 
-  public void setSparkProperties(Map<String, String> sparkProperties) {
-    if (sparkProperties != null && !sparkProperties.isEmpty()) {
-      this.sparkProperties = sparkProperties;
+  public void setConf(Map<String, String> conf) {
+    if (conf != null && !conf.isEmpty()) {
+      this.conf = conf;
     }
   }
 
@@ -61,9 +62,9 @@ public class ZipkinSparkStreamingProperties {
 
   SparkStreamingJob.Builder toBuilder() {
     SparkStreamingJob.Builder result = SparkStreamingJob.newBuilder();
-    if (sparkMaster != null) result.sparkMaster(sparkMaster);
-    if (sparkJars != null) result.sparkJars(sparkJars);
-    if (sparkProperties != null) result.sparkProperties(sparkProperties);
+    if (master != null) result.master(master);
+    if (jars != null) result.jars(jars);
+    if (!conf.isEmpty()) result.conf(conf);
     if (batchDuration != null) result.batchDuration(batchDuration);
     return result;
   }


### PR DESCRIPTION
Before we couldn't override spark properties via CLI. This fixes that
and prefers spark-submit names for settings we provide.

Ex. the last property is the same as you'd pass to spark-submit, except
prefixed with `zipkin.sparkstreaming.conf`:
```bash
$ java -jar sparkstreaming-job/target//zipkin-sparkstreaming-job-0.1.1-SNAPSHOT.jar \
  --zipkin.storage.type=elasticsearch \
  --zipkin.storage.elasticsearch.hosts=http://127.0.0.1:9200 \
  --zipkin.sparkstreaming.stream.kafka.bootstrap-servers=127.0.0.1:9092 \
  --zipkin.sparkstreaming.conf.spark.eventLog.enabled=false
```

Fixes #29