### PR TITLE
Switches serialization approach of storage components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <spark.version>1.6.3</spark.version>
 
     <!-- versions coupled to zipkin -->
-    <zipkin.version>2.2.3</zipkin.version>
+    <zipkin.version>2.4.1</zipkin.version>
     <cassandra-driver-core.version>3.3.1</cassandra-driver-core.version>
     <spring-boot.version>1.5.8.RELEASE</spring-boot.version>
   </properties>


### PR DESCRIPTION
Before, we serialized a pojo to manually create storage components when
in a spark job. This added maintenance as there are configuration items
such an approach will miss, such as okhttp auth interceptors. Now, we
serialize zipkin input properties and use spring to more realistically
reconstruct the storage component.

Fixes #45